### PR TITLE
Fix image name in README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Keeps the host datetime in sync
 
 ## Usage
 
-	docker run -d --privileged tutum/ntpdate
+	docker run -d --privileged tutum/ntpd


### PR DESCRIPTION
Fix usage example to match https://hub.docker.com/r/tutum/ntpd/

Thanks for making this. Used it to work around https://github.com/docker/for-mac/issues/17